### PR TITLE
Enforcing schema requirements

### DIFF
--- a/examples/security-insights-minimal-sample.yml
+++ b/examples/security-insights-minimal-sample.yml
@@ -19,4 +19,4 @@ security-contacts:
 contribution-policy:
   accepts-pull-requests: true
 vulnerability-reporting:
-  accepts-vulnerability-reports: true
+  accepts-vulnerability-reports: false

--- a/examples/security-insights-sample.yml.yml
+++ b/examples/security-insights-sample.yml.yml
@@ -34,7 +34,7 @@ contribution-policy:
 vulnerability-reporting:
   accepts-vulnerability-reports: true
   email-contact: security@something.com
-  more-information: https://foo.bar/reporting.html
+  security-policy: https://foo.bar/reporting.html
   bug-bounty-available: true
   bug-bounty-url: https://foo.bar/bugs.html
 security-testing:

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -128,6 +128,13 @@ properties:
                     threat-model-created:
                         $id: '#/properties/security-artifacts/properties/threat-model/properties/threat-model-created'
                         type: boolean
+                if:
+                    properties:
+                        threat-model-created:
+                            const: true
+                then:
+                    required:
+                    - evidence-url
                 required:
                 - threat-model-created
                 type: object
@@ -263,7 +270,7 @@ properties:
                 $id: '#/properties/vulnerability-reporting/properties/email-contact'
                 type: string
                 pattern: '^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$'
-            more-information:
+            security-policy:
                 $id: '#/properties/vulnerability-reporting/properties/more-information'
                 type: string
                 pattern: 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
@@ -271,6 +278,14 @@ properties:
                 $id: '#/properties/vulnerability-reporting/properties/pgp-key'
                 type: string
                 pattern: '^(-----BEGIN PGP PUBLIC KEY BLOCK-----).*([a-zA-Z0-9//\n\/\.\:\+\ \=]+).*(-----END PGP PUBLIC KEY BLOCK-----)$'
+        if:
+            properties:
+                accepts-vulnerability-reports:
+                    const: true
+        then:
+            required:
+            - email-contact
+            - security-policy
         required:
         - accepts-vulnerability-reports
         type: object


### PR DESCRIPTION
Enforcing `security-insights-schema-1.0.0.yaml`:

- if `threat-model-created` is true, then `evidence-url` is required
- if `accepts-vulnerability-reports` is true, then `email-contact` and `security-policy` are required