### PR TITLE
Require maintainers contacts under certain conditions

### DIFF
--- a/examples/security-insights-minimal-sample.yml
+++ b/examples/security-insights-minimal-sample.yml
@@ -8,6 +8,8 @@ header:
 project-lifecycle:
   stage: active
   bug-fixes-only: false
+  core-maintainers:
+  - https://github.com/scovetta
 security-artifacts:
   threat-model:
     threat-model-created: false

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -103,6 +103,20 @@ properties:
                 $id: '#/properties/project-lifecycle/properties/stage'
                 type: string
                 enum: ['active', 'inactive']
+        if:
+            properties:
+                stage:
+                    const: true
+        then:
+            required:
+            - core-maintainers
+        if:
+            properties:
+                bug-fixes-only:
+                    const: true
+        then:
+            required:
+            - core-maintainers
         required:
         - stage
         - bug-fixes-only

--- a/security-insights-schema-1.0.0.yaml
+++ b/security-insights-schema-1.0.0.yaml
@@ -106,7 +106,7 @@ properties:
         if:
             properties:
                 stage:
-                    const: true
+                    const: "active"
         then:
             required:
             - core-maintainers


### PR DESCRIPTION
Enforcing `security-insights-schema-1.0.0.yaml`:

- if `stage` or `bug-fixes-ony` are true, then `core-maintainers` is required